### PR TITLE
Bump dependencies / Improve performance

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,10 +40,22 @@ Concat.prototype.add = function(filePath, content, sourceMap) {
     content = new Buffer(content);
   }
 
-  if (this.content.length !== 0) {
-    this.content = Buffer.concat([this.content, this.separator]);
+  var chunks = [this.content];
+  var len = this.content.length;
+
+  if (len !== 0 && this.separator.length !== 0) {
+    chunks.push(this.separator);
+    len += this.separator.length;
   }
-  this.content = Buffer.concat([this.content, content]);
+
+  if (content.length !== 0) {
+    chunks.push(content);
+    len += content.length;
+  }
+
+  if (chunks.length > 1) {
+    this.content = Buffer.concat(chunks, len);
+  }
 
   if (this.sourceMapping) {
     var contentString = content.toString();

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "main": "index.js",
   "scripts": {
     "test": "jshint *.js test/*.js && faucet test/*.js",
-    "tap": "node node_modules/argg test/*.js",
-    "cover": "istanbul cover --dir reports/coverage node_modules/argg test/*.js",
-    "coveralls": "istanbul cover node_modules/argg test/*.js --report lcovonly && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage"
+    "tap": "tape test/*.js",
+    "cover": "istanbul cover --dir reports/coverage tape test/*.js",
+    "coveralls": "istanbul cover tape test/*.js --report lcovonly && istanbul-coveralls"
   },
   "keywords": [
     "concat",
@@ -21,11 +21,11 @@
     "source-map": "^0.3.0"
   },
   "devDependencies": {
-    "jshint": "^2.5.11",
-    "tape": "^3.0.3",
-    "argg": "0.0.1",
-    "istanbul": "^0.3.5",
+    "coveralls": "^2.10.0",
     "faucet": "0.0.1",
-    "coveralls": "^2.10.0"
+    "istanbul": "^0.3.5",
+    "istanbul-coveralls": "^1.0.1",
+    "jshint": "^2.5.11",
+    "tape": "^3.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Florian Reiterer <me@florianreiterer.com>",
   "license": "ISC",
   "dependencies": {
-    "source-map": "^0.1.41"
+    "source-map": "^0.3.0"
   },
   "devDependencies": {
     "jshint": "^2.5.11",


### PR DESCRIPTION
* I updated [source-map](https://www.npmjs.com/package/source-map) to v3.0.
* I updated devDependencies.
  * [argg](https://github.com/isao/argg) is not needed since [tape](https://github.com/substack/tape) supports globbing.
  * Introduce istanbul-coveralls
* I updated index.js to use the second argument of [`Buffer.concat`](http://nodejs.org/api/buffer.html#buffer_class_method_buffer_concat_list_totallength) for performance improvement.
  * Acccording to the API doc:
    
    > If totalLength is not provided, it is read from the buffers in the list. However, this adds an additional loop to the function, so it is faster to provide the length explicitly.