### PR TITLE
Add support for header and footer.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "concat-with-sourcemaps",
-  "version": "1.0.2",
+  "name": "concat-with-sourcemaps-next",
+  "version": "1.0.3",
   "description": "Concatenate file contents with a custom separator and generate a source map",
-  "homepage": "http://github.com/floridoo/concat-with-sourcemaps",
-  "repository": "git://github.com/floridoo/concat-with-sourcemaps.git",
+  "homepage": "http://github.com/marcominetti/concat-with-sourcemaps",
+  "repository": "git://github.com/marcominetti/concat-with-sourcemaps.git",
   "main": "index.js",
   "scripts": {
     "test": "jshint *.js test/*.js && faucet test/*.js",


### PR DESCRIPTION
Just added support for header and footer to be prepended and appended to contentParts and sourcemap offsets. No time to add tests, but yours pass and I'm using it with header, no problems.