### PR TITLE
For files without a previous sourcemap use content string as sourceContent

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,6 +95,8 @@ Concat.prototype.add = function(filePath, content, sourceMap) {
         }
         if (sourceMap && sourceMap.sourcesContent)
           this._sourceMap.setSourceContent(filePath, sourceMap.sourcesContent[0]);
+        if (!sourceMap || !sourceMap.sourcesContent)
+          this._sourceMap.setSourceContent(filePath, contentString);
       }
     }
     if (lines > 1)


### PR DESCRIPTION
This is a pr with a fix regarding to: #22