### PR TITLE
Fix TypeScript type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,10 @@
 import { RawSourceMap } from "source-map";
 
-declare module "concat-with-sourcemaps" {
-
-	export default class Concat {
-		constructor(generateSourceMap: boolean, fileName: string, separator?: string);
-		add(filePath: string | null, content: string | Buffer, sourceMap?: string | RawSourceMap): void;
-		readonly content: Buffer;
-		readonly sourceMap: string | undefined;
-	}
-
+declare class Concat {
+	constructor(generateSourceMap: boolean, fileName: string, separator?: string);
+	add(filePath: string | null, content: string | Buffer, sourceMap?: string | RawSourceMap): void;
+	readonly content: Buffer;
+	readonly sourceMap: string | undefined;
 }
+
+export = Concat;


### PR DESCRIPTION
There’s no need to use `declare module`. This is only useful to declare modules that don’t match the package name, e.g. to declare `fs` in `@types/node`.

This is a CommonJS module that uses `module.exports =`. The correct type definition is `export =`.

Technically the old type definitions work too, because `module.exports.default` is defined. However, with the new `"module": "node16"` option this means it should be used as follows in native ESM:

```ts
import Concat from 'concat-with-sourcemaps'

new Concat.default(true, 'all.js')
```

This is typically undesirable.